### PR TITLE
feat: Zoom TKL Dyna

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,6 +4525,9 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hidapi",
+ "image",
+ "rayon",
+ "rgb565",
  "zoom-sync-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,6 +4506,7 @@ dependencies = [
  "tray-icon",
  "windows",
  "zoom-sync-core",
+ "zoom-tkl-dyna",
  "zoom65v3",
 ]
 
@@ -4516,6 +4517,15 @@ dependencies = [
  "chrono",
  "hidapi",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "zoom-tkl-dyna"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "hidapi",
+ "zoom-sync-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 edition = "2021"
 
 [workspace]
-members = ["boards/core", "boards/zoom65v3"]
+members = ["boards/core", "boards/zoom65v3", "boards/zoom-tkl-dyna"]
 
 [workspace.dependencies]
 chrono = "0.4.38" # local time
@@ -18,6 +18,7 @@ hidapi = { version = "2.6", features = ["windows-native"] } # board detection
 # keyboard management
 zoom-sync-core = { path = "./boards/core", version = "0.1" }
 zoom65v3 = { path = "./boards/zoom65v3", version = "0.4" }
+zoom-tkl-dyna = { path = "./boards/zoom-tkl-dyna", version = "0.1" }
 hidapi = { workspace = true }
 
 # runtime and scaffalding

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zoom-sync"
 version = "0.2.0"
-description = "Cross-platform utility for syncing zoom65v3 screen modules"
+description = "Cross-platform utility for syncing Zoom keyboard screen modules"
 repository = "https://github.com/ozwaldorf/zoom-sync"
 authors = [ "ozwaldorf <self@ossian.dev>" ]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zoom-sync
 
-Cross-platform utility to sync Zoom65 v3 screen modules.
+Cross-platform utility to sync Meletrix Zoom Keyboard screen modules.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Cross-platform utility to sync Zoom65 v3 screen modules.
 | Reactive image/gif  | Simulated              | Not supported                   |
 | Future-proof        | Will always work       | Overflow errors after year 2255 |
 
+## Supported Boards
+
+| Feature             | Zoom65 V3          | Zoom TKL Dyna          |
+| ------------------- | ------------------ | ---------------------- |
+| Screen size         | 110x110            | 320x172                |
+| Time sync           | Yes                | Yes                    |
+| Weather             | Yes                | Yes                    |
+| System info         | Yes (CPU/GPU/DL)   | Needs research         |
+| Screen control      | Yes                | Not fully implemented  |
+| Image upload        | Yes                | Yes                    |
+| GIF upload          | Yes                | Yes                    |
+| Theme customization | Yes (Presets)      | Yes (Colors + Presets) |
+| 12hr time format    | Yes (simulated)    | No                     |
+
 ## Third Party Services
 
 The following free third-party services are used to fetch some information:

--- a/boards/core/src/board.rs
+++ b/boards/core/src/board.rs
@@ -62,4 +62,7 @@ pub trait Board: Send {
     fn as_gif(&mut self) -> Option<&mut dyn HasGif> {
         None
     }
+    fn as_theme(&mut self) -> Option<&mut dyn HasTheme> {
+        None
+    }
 }

--- a/boards/core/src/board.rs
+++ b/boards/core/src/board.rs
@@ -1,14 +1,14 @@
 //! Core Board trait and related types.
 
-use crate::features::{HasGif, HasImage, HasScreen, HasSystemInfo, HasTime, HasWeather};
+use crate::features::{HasGif, HasImage, HasScreen, HasSystemInfo, HasTheme, HasTime, HasWeather};
 
 /// Static information about a board type for detection and CLI
 #[derive(Debug, Clone, Copy)]
 pub struct BoardInfo {
     pub name: &'static str,
     pub cli_name: &'static str,
-    pub vendor_id: u16,
-    pub product_id: u16,
+    pub vendor_id: Option<u16>,
+    pub product_id: Option<u16>,
     pub usage_page: Option<u16>,
     pub usage: Option<u16>,
 }

--- a/boards/core/src/board.rs
+++ b/boards/core/src/board.rs
@@ -2,6 +2,18 @@
 
 use crate::features::{HasGif, HasImage, HasScreen, HasSystemInfo, HasTheme, HasTime, HasWeather};
 
+/// Static capability flags for a board (compile-time known)
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Capabilities {
+    pub time: bool,
+    pub weather: bool,
+    pub system_info: bool,
+    pub screen: bool,
+    pub image: bool,
+    pub gif: bool,
+    pub theme: bool,
+}
+
 /// Static information about a board type for detection and CLI
 #[derive(Debug, Clone, Copy)]
 pub struct BoardInfo {
@@ -11,6 +23,7 @@ pub struct BoardInfo {
     pub product_id: Option<u16>,
     pub usage_page: Option<u16>,
     pub usage: Option<u16>,
+    pub capabilities: Capabilities,
 }
 
 /// Screen position for menu building

--- a/boards/core/src/features.rs
+++ b/boards/core/src/features.rs
@@ -49,7 +49,9 @@ pub trait HasTime {
 /// Weather display capability
 pub trait HasWeather {
     /// Set weather display. WMO code is converted to board-specific icon internally.
-    fn set_weather(&mut self, wmo: u8, is_day: bool, current: u8, low: u8, high: u8) -> Result<()>;
+    /// Temperatures are in Celsius - each board converts to its native format.
+    fn set_weather(&mut self, wmo: u8, is_day: bool, current: i16, low: i16, high: i16)
+        -> Result<()>;
 }
 
 /// System info display capability (CPU temp, GPU temp, download speed)

--- a/boards/core/src/features.rs
+++ b/boards/core/src/features.rs
@@ -60,9 +60,9 @@ pub trait HasWeather {
     ) -> Result<()>;
 }
 
-/// System info display capability (CPU temp, GPU temp, download speed)
+/// System info display capability (CPU temp, GPU temp, download speed, fan speed (currently set to GPU fans w/gpu driver))
 pub trait HasSystemInfo {
-    fn set_system_info(&mut self, cpu: u8, gpu: u8, download: f32) -> Result<()>;
+    fn set_system_info(&mut self, cpu: u8, gpu: u32, download: f32, fan_rpm: u32) -> Result<()>;
 }
 
 /// Screen position control capability

--- a/boards/core/src/features.rs
+++ b/boards/core/src/features.rs
@@ -50,8 +50,14 @@ pub trait HasTime {
 pub trait HasWeather {
     /// Set weather display. WMO code is converted to board-specific icon internally.
     /// Temperatures are in Celsius - each board converts to its native format.
-    fn set_weather(&mut self, wmo: u8, is_day: bool, current: i16, low: i16, high: i16)
-        -> Result<()>;
+    fn set_weather(
+        &mut self,
+        wmo: u8,
+        is_day: bool,
+        current: i16,
+        low: i16,
+        high: i16,
+    ) -> Result<()>;
 }
 
 /// System info display capability (CPU temp, GPU temp, download speed)
@@ -60,20 +66,19 @@ pub trait HasSystemInfo {
 }
 
 /// Screen position control capability
-pub trait HasScreen {
+pub trait HasScreenPositions {
     /// Available screen positions for this board
     fn screen_positions(&self) -> &'static [ScreenPosition];
     /// Set screen by position ID (e.g., "cpu", "weather", "gif")
     fn set_screen(&mut self, id: &str) -> Result<()>;
+}
+
+/// Screen navigation capability
+pub trait HasScreenNavigation {
     fn screen_up(&mut self) -> Result<()>;
     fn screen_down(&mut self) -> Result<()>;
     fn screen_switch(&mut self) -> Result<()>;
-    fn reset_screen(&mut self) -> Result<()>;
-}
-
-/// Screen dimensions - boards with media support should also implement as_screen_size()
-pub trait HasScreenSize {
-    fn screen_size(&self) -> (u32, u32);
+    fn screen_reset(&mut self) -> Result<()>;
 }
 
 /// Static image upload capability

--- a/boards/core/src/features.rs
+++ b/boards/core/src/features.rs
@@ -87,3 +87,12 @@ pub trait HasGif {
     fn upload_gif(&mut self, data: &[u8], progress: &mut dyn FnMut(usize)) -> Result<()>;
     fn clear_gif(&mut self) -> Result<()>;
 }
+
+/// Theme customization capability (background color, font color)
+pub trait HasTheme {
+    /// Set screen theme with RGB565 colors
+    /// - bg_color: Background color as RGB565 (16-bit)
+    /// - font_color: Font color as RGB565 (16-bit)
+    /// - theme_id: Theme preset ID
+    fn set_theme(&mut self, bg_color: u16, font_color: u16, theme_id: u8) -> Result<()>;
+}

--- a/boards/core/src/lib.rs
+++ b/boards/core/src/lib.rs
@@ -8,8 +8,8 @@
 mod board;
 mod features;
 
-pub use board::{Board, BoardInfo, Capabilities, ScreenGroup, ScreenPosition};
+pub use board::{Board, BoardInfo, Capabilities, ScreenPosition};
 pub use features::{
-    BoardError, HasGif, HasImage, HasScreen, HasScreenSize, HasSystemInfo, HasTheme, HasTime,
-    HasWeather, Result,
+    BoardError, HasGif, HasImage, HasScreenNavigation, HasScreenPositions, HasSystemInfo, HasTheme,
+    HasTime, HasWeather, Result,
 };

--- a/boards/core/src/lib.rs
+++ b/boards/core/src/lib.rs
@@ -10,6 +10,6 @@ mod features;
 
 pub use board::{Board, BoardInfo, ScreenGroup, ScreenPosition};
 pub use features::{
-    BoardError, HasGif, HasImage, HasScreen, HasScreenSize, HasSystemInfo, HasTime, HasWeather,
-    Result,
+    BoardError, HasGif, HasImage, HasScreen, HasScreenSize, HasSystemInfo, HasTheme, HasTime,
+    HasWeather, Result,
 };

--- a/boards/core/src/lib.rs
+++ b/boards/core/src/lib.rs
@@ -8,7 +8,7 @@
 mod board;
 mod features;
 
-pub use board::{Board, BoardInfo, ScreenGroup, ScreenPosition};
+pub use board::{Board, BoardInfo, Capabilities, ScreenGroup, ScreenPosition};
 pub use features::{
     BoardError, HasGif, HasImage, HasScreen, HasScreenSize, HasSystemInfo, HasTheme, HasTime,
     HasWeather, Result,

--- a/boards/zoom-tkl-dyna/Cargo.toml
+++ b/boards/zoom-tkl-dyna/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2021"
 zoom-sync-core = { path = "../../zoom-sync-core" }
 hidapi = { workspace = true }
 chrono = { workspace = true }
+image = "0.25.5"
+rayon = "1.10.0"
+rgb565 = "0.1.3"

--- a/boards/zoom-tkl-dyna/Cargo.toml
+++ b/boards/zoom-tkl-dyna/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-zoom-sync-core = { path = "../../zoom-sync-core" }
+zoom-sync-core = { path = "../core", version = "0.1" }
 hidapi = { workspace = true }
 chrono = { workspace = true }
 image = "0.25.5"

--- a/boards/zoom-tkl-dyna/Cargo.toml
+++ b/boards/zoom-tkl-dyna/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zoom-tkl-dyna"
+version = "0.1.0"
+description = "Reverse engineered hidapi bindings to zoom-tkl-dyna screen modules"
+repository = "https://github.com/ozwaldorf/zoom-sync"
+authors = [ "ozwaldorf <self@ossian.dev>" ]
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+zoom-sync-core = { path = "../../zoom-sync-core" }
+hidapi = { workspace = true }
+chrono = { workspace = true }

--- a/boards/zoom-tkl-dyna/src/abi.rs
+++ b/boards/zoom-tkl-dyna/src/abi.rs
@@ -52,6 +52,7 @@ pub fn build_packet(command: u8, payload: &[u8], sub_type: u8) -> [u8; 32] {
             packet[12 + i] = byte;
         }
     }
+    println!("payload: {:?}", &payload);
 
     // Calculate checksum (sum of bytes 9+ XOR 0xFF)
     let mut checksum: u16 = 0;
@@ -73,10 +74,14 @@ pub fn build_packet(command: u8, payload: &[u8], sub_type: u8) -> [u8; 32] {
     packet[6] = (crc & 0xFF) as u8; // CRC low byte
     packet[7] = (crc >> 8) as u8; // CRC high byte
 
-    // Additional 0 padding byte, if we need the entire data field in the future
+    // Additional 0 padding byte - NOTE, this loses one byte off of the original packet, 
+    // so if we're setting packet[31] we're losing that byte. As far as I know, the largest
+    // thing we send through here is 16 bytes, which 12(starting point of data)+16=28, so
+    // we *should* be alright.
     let mut full_packet: [u8; 32] = [0u8; 32];
     full_packet[0] = 0x0;
     full_packet[1..32].copy_from_slice(&packet[..31]);
+    println!("packet: {:?}", &full_packet);
     full_packet
 }
 

--- a/boards/zoom-tkl-dyna/src/abi.rs
+++ b/boards/zoom-tkl-dyna/src/abi.rs
@@ -73,7 +73,11 @@ pub fn build_packet(command: u8, payload: &[u8], sub_type: u8) -> [u8; 32] {
     packet[6] = (crc & 0xFF) as u8; // CRC low byte
     packet[7] = (crc >> 8) as u8; // CRC high byte
 
-    packet
+    // Additional 0 padding byte, if we need the entire data field in the future
+    let mut full_packet: [u8; 32] = [0u8; 32];
+    full_packet[0] = 0x0;
+    full_packet[1..32].copy_from_slice(&packet[..31]);
+    full_packet
 }
 
 /// Build a datetime sync packet.

--- a/boards/zoom-tkl-dyna/src/abi.rs
+++ b/boards/zoom-tkl-dyna/src/abi.rs
@@ -1,0 +1,176 @@
+//! HID packet protocol implementation for Zoom TKL Dyna.
+//!
+//! Packet structure (32 bytes):
+//! - Byte 0: 0x1C (report type)
+//! - Byte 1: 0x02 or 0x03 (sub-type)
+//! - Bytes 2-4: Reserved (0)
+//! - Byte 5: Payload size (4 + dataLength + 1)
+//! - Bytes 6-7: CRC16 (little-endian)
+//! - Byte 8: 0xA5 (magic identifier)
+//! - Byte 9: Command byte
+//! - Byte 10: Reserved (0)
+//! - Byte 11: Payload length
+//! - Bytes 12+: Payload data
+//! - Final byte: Checksum (sum of bytes 9+ XOR 0xFF)
+
+use crate::crc::crc16;
+use crate::types::{Rgb565, ScreenMode, WeatherIcon};
+
+/// Command identifiers
+pub mod cmd {
+    /// DateTime sync command
+    pub const DATETIME: u8 = 0x38;
+    /// Screen control command
+    pub const SCREEN: u8 = 0x39;
+    /// Image upload command
+    pub const IMAGE: u8 = 0xFC;
+    /// Theme settings command
+    pub const THEME: u8 = 0xFD;
+    /// Weather display command
+    pub const WEATHER: u8 = 0xFE;
+}
+
+/// Build a 32-byte HID packet with proper framing, checksums, and CRC.
+///
+/// # Arguments
+/// * `command` - Command byte (e.g., 0x38 for datetime)
+/// * `payload` - Payload data (excluding command byte)
+/// * `sub_type` - Sub-type byte (0x02 for most commands, 0x03 for datetime)
+pub fn build_packet(command: u8, payload: &[u8], sub_type: u8) -> [u8; 32] {
+    let mut packet = [0u8; 32];
+    let data_length = payload.len();
+
+    // Magic and command structure
+    packet[8] = 0xA5; // Magic identifier
+    packet[9] = command; // Command byte
+    packet[10] = 0; // Reserved
+    packet[11] = data_length as u8; // Payload length
+
+    // Copy payload data
+    for (i, &byte) in payload.iter().enumerate() {
+        if 12 + i < 31 {
+            packet[12 + i] = byte;
+        }
+    }
+
+    // Calculate checksum (sum of bytes 9+ XOR 0xFF)
+    let mut checksum: u16 = 0;
+    for i in 9..32 {
+        checksum += packet[i] as u16;
+    }
+    let checksum_pos = 12 + data_length;
+    if checksum_pos < 32 {
+        packet[checksum_pos] = (checksum ^ 0xFF) as u8;
+    }
+
+    // Set packet header
+    packet[0] = 0x1C; // Report type
+    packet[1] = sub_type; // Sub-type
+    packet[5] = (4 + data_length + 1) as u8; // Payload size field
+
+    // Calculate and set CRC16 (little-endian)
+    let crc = crc16(&packet);
+    packet[6] = (crc & 0xFF) as u8; // CRC low byte
+    packet[7] = (crc >> 8) as u8; // CRC high byte
+
+    packet
+}
+
+/// Build a datetime sync packet.
+///
+/// Payload structure (10 bytes):
+/// - Bytes 0-1: Unknown flags (0x00, 0x01)
+/// - Bytes 2-3: Year (big-endian)
+/// - Byte 4: Month (1-12)
+/// - Byte 5: Day of month (1-31)
+/// - Byte 6: Hours (0-23)
+/// - Byte 7: Minutes (0-59)
+/// - Byte 8: Seconds (0-59)
+/// - Byte 9: Day of week (0=Sunday)
+pub fn datetime(
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+    day_of_week: u8,
+) -> [u8; 32] {
+    let payload = [
+        0x00,                  // Unknown flag 1
+        0x01,                  // Unknown flag 2
+        (year >> 8) as u8,     // Year high byte
+        (year & 0xFF) as u8,   // Year low byte
+        month,                 // Month (1-12)
+        day,                   // Day of month
+        hour,                  // Hours (0-23)
+        minute,                // Minutes (0-59)
+        second,                // Seconds (0-59)
+        day_of_week,           // Day of week (0=Sun)
+    ];
+    build_packet(cmd::DATETIME, &payload, 0x03)
+}
+
+/// Build a screen control packet.
+pub fn screen_control(mode: ScreenMode) -> [u8; 32] {
+    let payload = [0x00, mode as u8];
+    build_packet(cmd::SCREEN, &payload, 0x02)
+}
+
+/// Build a theme settings packet.
+///
+/// Payload structure (6 bytes):
+/// - Byte 0: Sub-command (0x00)
+/// - Bytes 1-2: Background color (RGB565, big-endian)
+/// - Bytes 3-4: Font color (RGB565, big-endian)
+/// - Byte 5: Theme ID
+pub fn theme(bg_color: Rgb565, font_color: Rgb565, theme_id: u8) -> [u8; 32] {
+    let bg = bg_color.to_be_bytes();
+    let font = font_color.to_be_bytes();
+    let payload = [0x00, bg[0], bg[1], font[0], font[1], theme_id];
+    build_packet(cmd::THEME, &payload, 0x02)
+}
+
+/// Build a weather display packet.
+///
+/// Payload structure (8 bytes):
+/// - Byte 0: Sub-command (0x00)
+/// - Byte 1: Weather icon (1-8)
+/// - Bytes 2-3: Current temp (encoded, big-endian)
+/// - Bytes 4-5: Max temp (encoded, big-endian)
+/// - Bytes 6-7: Min temp (encoded, big-endian)
+pub fn weather(icon: WeatherIcon, current: u16, max: u16, min: u16) -> [u8; 32] {
+    let payload = [
+        0x00,
+        icon as u8,
+        (current >> 8) as u8,
+        (current & 0xFF) as u8,
+        (max >> 8) as u8,
+        (max & 0xFF) as u8,
+        (min >> 8) as u8,
+        (min & 0xFF) as u8,
+    ];
+    build_packet(cmd::WEATHER, &payload, 0x02)
+}
+
+/// Build an image data chunk packet.
+///
+/// Payload structure:
+/// - Byte 0: Sub-command (0x00)
+/// - Bytes 1-2: Page index (big-endian)
+/// - Bytes 3+: Chunk data (up to 16 bytes)
+pub fn image_chunk(page_index: u16, chunk: &[u8]) -> [u8; 32] {
+    let mut payload = vec![
+        0x00,
+        (page_index >> 8) as u8,
+        (page_index & 0xFF) as u8,
+    ];
+    payload.extend_from_slice(chunk);
+    build_packet(cmd::IMAGE, &payload, 0x02)
+}
+
+/// Build an image upload termination packet.
+pub fn image_end() -> [u8; 32] {
+    let payload = [0x00, 0xFF, 0xFF];
+    build_packet(cmd::IMAGE, &payload, 0x02)
+}

--- a/boards/zoom-tkl-dyna/src/abi.rs
+++ b/boards/zoom-tkl-dyna/src/abi.rs
@@ -75,7 +75,7 @@ pub fn build_packet(command: u8, payload: &[u8], sub_type: u8) -> [u8; 32] {
     packet[6] = (crc & 0xFF) as u8; // CRC low byte
     packet[7] = (crc >> 8) as u8; // CRC high byte
 
-    // Additional 0 padding byte - NOTE, this loses one byte off of the original packet, 
+    // Additional 0 padding byte - NOTE, this loses one byte off of the original packet,
     // so if we're setting packet[31] we're losing that byte. As far as I know, the largest
     // thing we send through here is 16 bytes, which 12(starting point of data)+16=28, so
     // we *should* be alright.
@@ -185,12 +185,12 @@ pub fn image_end() -> [u8; 32] {
 /// - Byte 0: Unknown flag (0x00)
 /// - Byte 1-2: CPU Temp (big-endian)
 /// - Bytes 3-4: GPU Temp (big-endian)
-/// - Byte 5-6: Unknown Identifier, I speculated that it might SSD Temp looking at 
-///             the payload at one point but it doesn't display on screen anywhere.
+/// - Byte 5-6: Unknown Identifier, I speculated that it might SSD Temp looking at
+///   the payload at one point but it doesn't display on screen anywhere.
 /// - Byte 7-8: Fan RPM (big-endian)
 /// - Byte 9-10: Download Speed (big-endian)
 /// - Byte 11: 0xFF, (magic identifier)
-pub fn set_system_info(cpu_temp: u8, gpu_temp: u32, download: f32, fan_rpm: u32 ) -> [u8; 32] {
+pub fn set_system_info(cpu_temp: u8, gpu_temp: u32, download: f32, fan_rpm: u32) -> [u8; 32] {
     let gpu_temp_bytes: [u8; 4] = gpu_temp.to_be_bytes();
     let download_bytes: [u8; 4] = ((download * 10.0) as u32).to_be_bytes();
     let fan_rpm_bytes: [u8; 4] = fan_rpm.to_be_bytes();
@@ -207,7 +207,7 @@ pub fn set_system_info(cpu_temp: u8, gpu_temp: u32, download: f32, fan_rpm: u32 
         fan_rpm_bytes[3],
         download_bytes[2],
         download_bytes[3],
-        0xFF
+        0xFF,
     ];
     build_packet(cmd::SYSINFO, &payload, 0x02)
 }

--- a/boards/zoom-tkl-dyna/src/crc.rs
+++ b/boards/zoom-tkl-dyna/src/crc.rs
@@ -1,0 +1,34 @@
+//! CRC-16/CCITT-FALSE checksum implementation.
+//!
+//! Polynomial: 0x1021, Initial: 0xFFFF, No reflection, No final XOR
+
+/// Calculate CRC-16/CCITT-FALSE checksum
+pub fn crc16(data: &[u8]) -> u16 {
+    let mut crc: u16 = 0xFFFF;
+    for byte in data {
+        crc ^= (*byte as u16) << 8;
+        for _ in 0..8 {
+            if (crc & 0x8000) != 0 {
+                crc = (crc << 1) ^ 0x1021;
+            } else {
+                crc <<= 1;
+            }
+            crc &= 0xFFFF;
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc16_basic() {
+        // Test with known values
+        let data = [0xA5, 0x38, 0x00, 0x0A];
+        let result = crc16(&data);
+        // CRC should be consistent
+        assert_eq!(crc16(&data), result);
+    }
+}

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -1,0 +1,226 @@
+//! High level hidapi abstraction for interacting with Zoom TKL Dyna screen modules.
+//!
+//! This crate provides reverse-engineered bindings to control the Zoom TKL Dyna keyboard's
+//! built-in display via HID. The protocol uses CRC-16/CCITT-FALSE checksums with a 32-byte
+//! packet structure.
+//!
+//! Screen size: 320x172 pixels, RGB565 format.
+
+use std::sync::{LazyLock, RwLock};
+
+use chrono::{DateTime, Datelike, Local, TimeZone, Timelike};
+use hidapi::{HidApi, HidDevice};
+use types::{encode_temperature, Rgb565, ScreenMode, WeatherIcon};
+use zoom_sync_core::{
+    Board, BoardError, BoardInfo, HasImage, HasTheme, HasTime, HasWeather, Result,
+};
+
+pub mod abi;
+pub mod crc;
+pub mod types;
+
+pub mod consts {
+    /// HID usage page for the Zoom TKL Dyna screen interface
+    pub const USAGE_PAGE: u16 = 65376;
+    /// HID usage for the Zoom TKL Dyna screen interface
+    pub const USAGE: u16 = 97;
+}
+
+/// Static board info for detection
+pub static INFO: BoardInfo = BoardInfo {
+    name: "Zoom TKL Dyna",
+    cli_name: "zoom-tkl-dyna",
+    vendor_id: None,
+    product_id: None,
+    usage_page: Some(consts::USAGE_PAGE),
+    usage: Some(consts::USAGE),
+};
+
+/// Screen dimensions
+pub const SCREEN_WIDTH: u32 = 320;
+pub const SCREEN_HEIGHT: u32 = 172;
+
+/// Lazy handle to hidapi
+static API: LazyLock<RwLock<HidApi>> =
+    LazyLock::new(|| RwLock::new(HidApi::new().expect("failed to init hidapi")));
+
+/// High level abstraction for managing a Zoom TKL Dyna keyboard
+pub struct ZoomTklDyna {
+    pub device: HidDevice,
+    buf: [u8; 64],
+}
+
+impl ZoomTklDyna {
+    /// Find and open the device for modifications
+    pub fn open() -> Result<Self> {
+        API.write().unwrap().refresh_devices()?;
+        let api = API.read().unwrap();
+        let this = Self {
+            device: api
+                .device_list()
+                .find(|d| {
+                    d.usage_page() == consts::USAGE_PAGE && d.usage() == consts::USAGE
+                })
+                .ok_or(BoardError::DeviceNotFound)?
+                .open_device(&api)?,
+            buf: [0u8; 64],
+        };
+
+        Ok(this)
+    }
+
+    /// Internal method to execute a packet and optionally read the response
+    fn execute(&mut self, packet: [u8; 32]) -> Result<()> {
+        self.device.write(&packet)?;
+        // Read response if available
+        let _ = self.device.read_timeout(&mut self.buf, 100);
+        Ok(())
+    }
+
+    /// Sync the current date and time to the keyboard display.
+    pub fn set_time<Tz: TimeZone>(&mut self, time: DateTime<Tz>) -> Result<()> {
+        let packet = abi::datetime(
+            time.year() as u16,
+            time.month() as u8,
+            time.day() as u8,
+            time.hour() as u8,
+            time.minute() as u8,
+            time.second() as u8,
+            time.weekday().num_days_from_sunday() as u8,
+        );
+        self.execute(packet)
+    }
+
+    /// Update the weather display.
+    pub fn set_weather(
+        &mut self,
+        icon: WeatherIcon,
+        current: i16,
+        low: i16,
+        high: i16,
+    ) -> Result<()> {
+        let packet = abi::weather(
+            icon,
+            encode_temperature(current),
+            encode_temperature(high),
+            encode_temperature(low),
+        );
+        self.execute(packet)
+    }
+
+    /// Set the screen theme colors.
+    pub fn set_theme(
+        &mut self,
+        bg_color: Rgb565,
+        font_color: Rgb565,
+        theme_id: u8,
+    ) -> Result<()> {
+        let packet = abi::theme(bg_color, font_color, theme_id);
+        self.execute(packet)
+    }
+
+    /// Send a screen control command.
+    pub fn screen_control(&mut self, mode: ScreenMode) -> Result<()> {
+        let packet = abi::screen_control(mode);
+        self.execute(packet)
+    }
+
+    /// Refresh the screen (mode 2).
+    pub fn screen_refresh(&mut self) -> Result<()> {
+        self.screen_control(ScreenMode::Refresh)
+    }
+
+    /// Next screen/theme (mode 3).
+    pub fn screen_next(&mut self) -> Result<()> {
+        self.screen_control(ScreenMode::Next)
+    }
+
+    /// Previous screen/theme (mode 4).
+    pub fn screen_previous(&mut self) -> Result<()> {
+        self.screen_control(ScreenMode::Previous)
+    }
+
+    /// Upload an image to the keyboard screen.
+    ///
+    /// The image data should be in RGB565 format with a 452-byte header.
+    /// Screen size is 320x172 pixels.
+    pub fn upload_image(&mut self, data: &[u8], cb: &mut dyn FnMut(usize)) -> Result<()> {
+        const CHUNK_SIZE: usize = 16;
+        let page_count = (data.len() + CHUNK_SIZE - 1) / CHUNK_SIZE;
+
+        // Send each chunk
+        for (page_index, chunk) in data.chunks(CHUNK_SIZE).enumerate() {
+            cb(page_index);
+            let packet = abi::image_chunk(page_index as u16, chunk);
+            self.execute(packet)?;
+        }
+
+        // Send termination packet
+        let packet = abi::image_end();
+        self.execute(packet)?;
+
+        cb(page_count);
+        Ok(())
+    }
+}
+
+// === Trait Implementations ===
+
+impl Board for ZoomTklDyna {
+    fn info(&self) -> &'static BoardInfo {
+        &INFO
+    }
+
+    fn as_time(&mut self) -> Option<&mut dyn HasTime> {
+        Some(self)
+    }
+
+    fn as_weather(&mut self) -> Option<&mut dyn HasWeather> {
+        Some(self)
+    }
+
+    fn as_screen_size(&self) -> Option<(u32, u32)> {
+        Some((SCREEN_WIDTH, SCREEN_HEIGHT))
+    }
+
+    fn as_image(&mut self) -> Option<&mut dyn HasImage> {
+        Some(self)
+    }
+
+    fn as_theme(&mut self) -> Option<&mut dyn HasTheme> {
+        Some(self)
+    }
+}
+
+impl HasTime for ZoomTklDyna {
+    fn set_time(&mut self, time: DateTime<Local>, _use_12hr: bool) -> Result<()> {
+        // Note: The TKL Dyna uses 24-hour format internally, so we ignore _use_12hr
+        ZoomTklDyna::set_time(self, time)
+    }
+}
+
+impl HasWeather for ZoomTklDyna {
+    fn set_weather(&mut self, wmo: u8, is_day: bool, current: i16, low: i16, high: i16) -> Result<()> {
+        let icon = WeatherIcon::from_wmo(wmo, is_day)
+            .ok_or(BoardError::CommandFailed("unknown WMO code"))?;
+        ZoomTklDyna::set_weather(self, icon, current, low, high)
+    }
+}
+
+impl HasImage for ZoomTklDyna {
+    fn upload_image(&mut self, data: &[u8], progress: &mut dyn FnMut(usize)) -> Result<()> {
+        ZoomTklDyna::upload_image(self, data, progress)
+    }
+
+    fn clear_image(&mut self) -> Result<()> {
+        // Send empty termination to clear
+        let packet = abi::image_end();
+        self.execute(packet)
+    }
+}
+
+impl HasTheme for ZoomTklDyna {
+    fn set_theme(&mut self, bg_color: u16, font_color: u16, theme_id: u8) -> Result<()> {
+        ZoomTklDyna::set_theme(self, Rgb565(bg_color), Rgb565(font_color), theme_id)
+    }
+}

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Datelike, Local, TimeZone, Timelike};
 use hidapi::{HidApi, HidDevice};
 use types::{encode_temperature, Rgb565, ScreenMode, WeatherIcon};
 use zoom_sync_core::{
-    Board, BoardError, BoardInfo, HasImage, HasTheme, HasTime, HasWeather, Result,
+    Board, BoardError, BoardInfo, Capabilities, HasImage, HasTheme, HasTime, HasWeather, Result,
 };
 
 pub mod abi;
@@ -34,6 +34,15 @@ pub static INFO: BoardInfo = BoardInfo {
     product_id: None,
     usage_page: Some(consts::USAGE_PAGE),
     usage: Some(consts::USAGE),
+    capabilities: Capabilities {
+        time: true,
+        weather: true,
+        system_info: false,
+        screen: false,
+        image: true,
+        gif: false,
+        theme: true,
+    },
 };
 
 /// Screen dimensions

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -161,7 +161,12 @@ impl ZoomTklDyna {
         let this = Self {
             device: api
                 .device_list()
-                .find(|d| d.usage_page() == consts::USAGE_PAGE && d.usage() == consts::USAGE)
+                .find(|d| {
+                    d.vendor_id() == consts::VENDOR_ID
+                        && d.product_id() == consts::PRODUCT_ID
+                        && d.usage_page() == consts::USAGE_PAGE
+                        && d.usage() == consts::USAGE
+                })
                 .ok_or(BoardError::DeviceNotFound)?
                 .open_device(&api)?,
             buf: [0u8; 64],

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -50,7 +50,8 @@ pub static INFO: BoardInfo = BoardInfo {
         weather: true,
         image: true,
         system_info: false,
-        screen: false,
+        screen_pos: false,
+        screen_nav: false,
         gif: true,
     },
 };

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -17,7 +17,8 @@ use image::AnimationDecoder;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use types::{encode_temperature, Rgb565, ScreenMode, WeatherIcon};
 use zoom_sync_core::{
-    Board, BoardError, BoardInfo, Capabilities, HasGif, HasImage, HasScreenNavigation, HasSystemInfo, HasTheme, HasTime, HasWeather, Result
+    Board, BoardError, BoardInfo, Capabilities, HasGif, HasImage, HasScreenNavigation,
+    HasSystemInfo, HasTheme, HasTime, HasWeather, Result,
 };
 
 pub mod abi;
@@ -213,7 +214,7 @@ impl ZoomTklDyna {
         );
         self.execute(packet)
     }
-    
+
     /// Update the system info display
     pub fn set_system_info(
         &mut self,
@@ -222,14 +223,14 @@ impl ZoomTklDyna {
         download_rate: f32,
         gpu_fan_speed: u32,
     ) -> Result<()> {
-
         let mut gpu_fan_speed_adjusted = gpu_fan_speed;
         if gpu_fan_speed >= 10000 {
             eprintln!("warning: actual fan speed at {gpu_fan_speed}. clamping to 9999");
             gpu_fan_speed_adjusted = 9999;
         }
 
-        let packet = abi::set_system_info(cpu_temp, gpu_temp, download_rate, gpu_fan_speed_adjusted);
+        let packet =
+            abi::set_system_info(cpu_temp, gpu_temp, download_rate, gpu_fan_speed_adjusted);
         self.execute(packet)
     }
 
@@ -417,7 +418,7 @@ impl HasWeather for ZoomTklDyna {
     }
 }
 
-impl HasSystemInfo for  ZoomTklDyna {
+impl HasSystemInfo for ZoomTklDyna {
     fn set_system_info(&mut self, cpu: u8, gpu: u32, download: f32, fan_rpm: u32) -> Result<()> {
         ZoomTklDyna::set_system_info(self, cpu, gpu, download, fan_rpm)
     }

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -17,8 +17,7 @@ use image::AnimationDecoder;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use types::{encode_temperature, Rgb565, ScreenMode, WeatherIcon};
 use zoom_sync_core::{
-    Board, BoardError, BoardInfo, Capabilities, HasGif, HasImage, HasScreenNavigation, HasTheme,
-    HasTime, HasWeather, Result,
+    Board, BoardError, BoardInfo, Capabilities, HasGif, HasImage, HasScreenNavigation, HasSystemInfo, HasTheme, HasTime, HasWeather, Result
 };
 
 pub mod abi;
@@ -49,7 +48,7 @@ pub static INFO: BoardInfo = BoardInfo {
         time: true,
         weather: true,
         image: true,
-        system_info: false,
+        system_info: true,
         screen_pos: false,
         screen_nav: true,
         gif: true,
@@ -214,6 +213,25 @@ impl ZoomTklDyna {
         );
         self.execute(packet)
     }
+    
+    /// Update the system info display
+    pub fn set_system_info(
+        &mut self,
+        cpu_temp: u8,
+        gpu_temp: u32,
+        download_rate: f32,
+        gpu_fan_speed: u32,
+    ) -> Result<()> {
+
+        let mut gpu_fan_speed_adjusted = gpu_fan_speed;
+        if gpu_fan_speed >= 10000 {
+            eprintln!("warning: actual fan speed at {gpu_fan_speed}. clamping to 9999");
+            gpu_fan_speed_adjusted = 9999;
+        }
+
+        let packet = abi::set_system_info(cpu_temp, gpu_temp, download_rate, gpu_fan_speed_adjusted);
+        self.execute(packet)
+    }
 
     /// Set the screen theme colors.
     /// For TKL Dyna, this sets the reactive typing color themeing built into the screen.
@@ -325,6 +343,10 @@ impl Board for ZoomTklDyna {
     fn as_weather(&mut self) -> Option<&mut dyn HasWeather> {
         Some(self)
     }
+
+    fn as_system_info(&mut self) -> Option<&mut dyn HasSystemInfo> {
+        Some(self)
+    }
 }
 
 impl HasTheme for ZoomTklDyna {
@@ -392,5 +414,11 @@ impl HasWeather for ZoomTklDyna {
         let icon = WeatherIcon::from_wmo(wmo, is_day)
             .ok_or(BoardError::CommandFailed("unknown WMO code"))?;
         ZoomTklDyna::set_weather(self, icon, current, low, high)
+    }
+}
+
+impl HasSystemInfo for  ZoomTklDyna {
+    fn set_system_info(&mut self, cpu: u8, gpu: u32, download: f32, fan_rpm: u32) -> Result<()> {
+        ZoomTklDyna::set_system_info(self, cpu, gpu, download, fan_rpm)
     }
 }

--- a/boards/zoom-tkl-dyna/src/types.rs
+++ b/boards/zoom-tkl-dyna/src/types.rs
@@ -1,0 +1,142 @@
+//! Type definitions for Zoom TKL Dyna keyboard.
+
+/// Weather condition icons for the keyboard display.
+/// These map to the display icon indices.
+/// Note: Some icons may share visual representations on the device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum WeatherIcon {
+    Unknown = 0,
+    SunnyDay = 1,
+    PartlyCloudyDay = 2,
+    Cloudy = 5,
+    ClearNight = 6,
+    PartlyCloudyNight = 7,
+    Thunderstorm = 8,
+    // Rain and Snow use separate indices based on the deobfuscated protocol
+    Rain = 3,
+    Snow = 4,
+}
+
+impl WeatherIcon {
+    /// Convert a WMO weather code to a display icon, adapting for day/night.
+    /// Based on the Weather API condition codes from the deobfuscated protocol.
+    pub fn from_wmo(wmo: u8, is_day: bool) -> Option<Self> {
+        match wmo {
+            // Clear and mainly clear
+            0 | 1 => Some(if is_day {
+                WeatherIcon::SunnyDay
+            } else {
+                WeatherIcon::ClearNight
+            }),
+
+            // Partly cloudy
+            2 => Some(if is_day {
+                WeatherIcon::PartlyCloudyDay
+            } else {
+                WeatherIcon::PartlyCloudyNight
+            }),
+
+            // Overcast and foggy
+            3 | 45 | 48 => Some(WeatherIcon::Cloudy),
+
+            // Drizzle, freezing drizzle, rain, freezing rain
+            51 | 53 | 55 | 56 | 57 | 61 | 63 | 65 | 66 | 67 => Some(WeatherIcon::Rain),
+
+            // Rain showers
+            80..=82 => Some(WeatherIcon::Rain),
+
+            // Snowfall and snow showers
+            71 | 73 | 75 | 77 | 85 | 86 => Some(WeatherIcon::Snow),
+
+            // Thunderstorm
+            95 | 96 | 99 => Some(WeatherIcon::Thunderstorm),
+
+            _ => None,
+        }
+    }
+}
+
+/// Screen control modes.
+/// These correspond to the 0x39 command sub-modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ScreenMode {
+    /// Mode 2 - possibly refresh/toggle
+    Refresh = 2,
+    /// Mode 3 - possibly next theme / screen on
+    Next = 3,
+    /// Mode 4 - possibly prev theme / screen off
+    Previous = 4,
+}
+
+/// Encode a temperature value for the keyboard protocol.
+/// Format: value * 10, with bit 15 set for negative temperatures.
+#[inline]
+pub fn encode_temperature(temp_celsius: i16) -> u16 {
+    if temp_celsius >= 0 {
+        (temp_celsius * 10) as u16
+    } else {
+        ((-temp_celsius) * 10) as u16 | 0x8000
+    }
+}
+
+/// RGB565 color for theme settings.
+/// 5 bits red, 6 bits green, 5 bits blue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rgb565(pub u16);
+
+impl Rgb565 {
+    /// Create RGB565 from 8-bit RGB values.
+    pub fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        let r5 = ((r >> 3) & 0x1F) as u16;
+        let g6 = ((g >> 2) & 0x3F) as u16;
+        let b5 = ((b >> 3) & 0x1F) as u16;
+        Rgb565((r5 << 11) | (g6 << 5) | b5)
+    }
+
+    /// Get the big-endian bytes for transmission.
+    #[inline]
+    pub fn to_be_bytes(self) -> [u8; 2] {
+        self.0.to_be_bytes()
+    }
+
+    /// Get the little-endian bytes for transmission.
+    #[inline]
+    pub fn to_le_bytes(self) -> [u8; 2] {
+        self.0.to_le_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_temperature_positive() {
+        assert_eq!(encode_temperature(25), 250);
+        assert_eq!(encode_temperature(0), 0);
+        assert_eq!(encode_temperature(100), 1000);
+    }
+
+    #[test]
+    fn test_encode_temperature_negative() {
+        assert_eq!(encode_temperature(-10), 100 | 0x8000);
+        assert_eq!(encode_temperature(-1), 10 | 0x8000);
+    }
+
+    #[test]
+    fn test_rgb565() {
+        // Pure red
+        let red = Rgb565::from_rgb(255, 0, 0);
+        assert_eq!(red.0, 0xF800);
+
+        // Pure green
+        let green = Rgb565::from_rgb(0, 255, 0);
+        assert_eq!(green.0, 0x07E0);
+
+        // Pure blue
+        let blue = Rgb565::from_rgb(0, 0, 255);
+        assert_eq!(blue.0, 0x001F);
+    }
+}

--- a/boards/zoom-tkl-dyna/src/types.rs
+++ b/boards/zoom-tkl-dyna/src/types.rs
@@ -77,13 +77,13 @@ pub enum ScreenMode {
 impl ScreenMode {
     /// Get the two-byte payload for this screen mode.
     /// Format: [command, checksum] where checksum = 0xC4 - command (or 0xC8 for reset)
-    pub fn to_bytes(self) -> [u8; 2] {
+    pub fn to_bytes(self) -> [u8; 3] {
         match self {
-            ScreenMode::Up => [0x02, 0xC4 - 0x02],
-            ScreenMode::Down => [0x01, 0xC4 - 0x01],
-            ScreenMode::Enter => [0x03, 0xC4 - 0x03],
-            ScreenMode::Return => [0x04, 0xC4 - 0x04],
-            ScreenMode::Reset => [0x01, 0xC8],
+            ScreenMode::Up => [0x00, 0x02, 0xC4 - 0x02],
+            ScreenMode::Down => [0x00, 0x01, 0xC4 - 0x01],
+            ScreenMode::Enter => [0x00, 0x03, 0xC4 - 0x03],
+            ScreenMode::Return => [0x00, 0x04, 0xC4 - 0x04],
+            ScreenMode::Reset => [0x00, 0x01, 0xC8],
         }
     }
 }

--- a/boards/zoom-tkl-dyna/src/types.rs
+++ b/boards/zoom-tkl-dyna/src/types.rs
@@ -58,16 +58,34 @@ impl WeatherIcon {
 }
 
 /// Screen control modes.
-/// These correspond to the 0x39 command sub-modes.
+/// These correspond to the 0x39 command with two-byte payload.
+/// The second byte is a checksum: 0xC4 - first_byte for navigation, 0xC8 for reset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
 pub enum ScreenMode {
-    /// Mode 2 - possibly refresh/toggle
-    Refresh = 2,
-    /// Mode 3 - possibly next theme / screen on
-    Next = 3,
-    /// Mode 4 - possibly prev theme / screen off
-    Previous = 4,
+    /// Navigate up in menu (cmd=2)
+    Up,
+    /// Navigate down in menu (cmd=1)
+    Down,
+    /// Enter/select menu item (cmd=3)
+    Enter,
+    /// Return/back from menu (cmd=4)
+    Return,
+    /// Reset themes, gifs and images (cmd=1, special checksum)
+    Reset,
+}
+
+impl ScreenMode {
+    /// Get the two-byte payload for this screen mode.
+    /// Format: [command, checksum] where checksum = 0xC4 - command (or 0xC8 for reset)
+    pub fn to_bytes(self) -> [u8; 2] {
+        match self {
+            ScreenMode::Up => [0x02, 0xC4 - 0x02],
+            ScreenMode::Down => [0x01, 0xC4 - 0x01],
+            ScreenMode::Enter => [0x03, 0xC4 - 0x03],
+            ScreenMode::Return => [0x04, 0xC4 - 0x04],
+            ScreenMode::Reset => [0x01, 0xC8],
+        }
+    }
 }
 
 /// Encode a temperature value for the keyboard protocol.

--- a/boards/zoom65v3/Cargo.toml
+++ b/boards/zoom65v3/Cargo.toml
@@ -8,6 +8,6 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-zoom-sync-core = { path = "../core" }
+zoom-sync-core = { path = "../core", version = "0.1" }
 hidapi = { workspace = true }
 chrono = { workspace = true }

--- a/boards/zoom65v3/src/lib.rs
+++ b/boards/zoom65v3/src/lib.rs
@@ -28,8 +28,8 @@ pub mod consts {
 pub static INFO: BoardInfo = BoardInfo {
     name: "Zoom65 V3",
     cli_name: "zoom65v3",
-    vendor_id: consts::ZOOM65_VENDOR_ID,
-    product_id: consts::ZOOM65_PRODUCT_ID,
+    vendor_id: Some(consts::ZOOM65_VENDOR_ID),
+    product_id: Some(consts::ZOOM65_PRODUCT_ID),
     usage_page: Some(consts::ZOOM65_USAGE_PAGE),
     usage: Some(consts::ZOOM65_USAGE),
 };
@@ -401,10 +401,17 @@ impl HasTime for Zoom65v3 {
 }
 
 impl HasWeather for Zoom65v3 {
-    fn set_weather(&mut self, wmo: u8, is_day: bool, current: u8, low: u8, high: u8) -> Result<()> {
+    fn set_weather(&mut self, wmo: u8, is_day: bool, current: i16, low: i16, high: i16) -> Result<()> {
         let icon =
             Icon::from_wmo(wmo, is_day).ok_or(BoardError::CommandFailed("unknown WMO code"))?;
-        Zoom65v3::set_weather(self, icon, current, low, high)
+        // Clamp to u8 range for this board's protocol
+        Zoom65v3::set_weather(
+            self,
+            icon,
+            current.clamp(0, 255) as u8,
+            low.clamp(0, 255) as u8,
+            high.clamp(0, 255) as u8,
+        )
     }
 }
 

--- a/boards/zoom65v3/src/lib.rs
+++ b/boards/zoom65v3/src/lib.rs
@@ -194,11 +194,12 @@ impl Zoom65v3 {
     pub fn set_system_info(
         &mut self,
         cpu_temp: u8,
-        gpu_temp: u8,
+        gpu_temp: u32,
         download_rate: f32,
     ) -> Result<()> {
         let download = DumbFloat16::new(download_rate);
-        let res = self.execute(abi::set_system_info(cpu_temp, gpu_temp, download))?;
+        let gpu_temp_cast: [u8; 4] = gpu_temp.to_be_bytes();
+        let res = self.execute(abi::set_system_info(cpu_temp, gpu_temp_cast[3], download))?;
         (res[1] == 1 && res[2] == 1)
             .then_some(())
             .ok_or(BoardError::CommandFailed("device rejected command"))
@@ -379,8 +380,9 @@ impl HasWeather for Zoom65v3 {
     }
 }
 
+// fan speed (the 4th arg for sysinfo) not supported on zoom65v3, thus not included.
 impl HasSystemInfo for Zoom65v3 {
-    fn set_system_info(&mut self, cpu: u8, gpu: u8, download: f32) -> Result<()> {
+    fn set_system_info(&mut self, cpu: u8, gpu: u32, download: f32, _: u32) -> Result<()> {
         Zoom65v3::set_system_info(self, cpu, gpu, download)
     }
 }

--- a/boards/zoom65v3/src/lib.rs
+++ b/boards/zoom65v3/src/lib.rs
@@ -8,8 +8,8 @@ use float::DumbFloat16;
 use hidapi::{HidApi, HidDevice};
 use types::{Icon, ScreenPosition, ScreenTheme, UploadChannel};
 use zoom_sync_core::{
-    Board, BoardError, BoardInfo, HasGif, HasImage, HasScreen, HasScreenSize, HasSystemInfo,
-    HasTime, HasWeather, Result, ScreenGroup, ScreenPosition as CoreScreenPosition,
+    Board, BoardError, BoardInfo, Capabilities, HasGif, HasImage, HasScreen, HasScreenSize,
+    HasSystemInfo, HasTime, HasWeather, Result, ScreenGroup, ScreenPosition as CoreScreenPosition,
 };
 
 pub mod abi;
@@ -32,6 +32,15 @@ pub static INFO: BoardInfo = BoardInfo {
     product_id: Some(consts::ZOOM65_PRODUCT_ID),
     usage_page: Some(consts::ZOOM65_USAGE_PAGE),
     usage: Some(consts::ZOOM65_USAGE),
+    capabilities: Capabilities {
+        time: true,
+        weather: true,
+        system_info: true,
+        screen: true,
+        image: true,
+        gif: true,
+        theme: false,
+    },
 };
 
 /// Screen positions for this board

--- a/boards/zoom65v3/src/types.rs
+++ b/boards/zoom65v3/src/types.rs
@@ -136,7 +136,7 @@ impl FromStr for ScreenPosition {
             "time" | "t" => Ok(Self::Time(TimeOffset::Time)),
             "weather" | "w" => Ok(Self::Time(TimeOffset::Weather)),
             "meletrix" | "m" => Ok(Self::Logo(LogoOffset::Meletrix)),
-            "zoom65" | "z" => Ok(Self::Logo(LogoOffset::Zoom65)),
+            "zoom" | "z" => Ok(Self::Logo(LogoOffset::Zoom)),
             "image" | "i" => Ok(Self::Logo(LogoOffset::Image)),
             "gif" | "g" => Ok(Self::Logo(LogoOffset::Gif)),
             "battery" | "b" => Ok(Self::Battery),
@@ -182,7 +182,7 @@ impl TimeOffset {
 pub enum LogoOffset {
     #[default]
     Meletrix = 0,
-    Zoom65 = 1,
+    Zoom = 1,
     Image = 2,
     Gif = 3,
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,15 +19,23 @@
 
 ## zoom-sync
 
-Cross-platform utility for syncing zoom65v3 screen modules
+Cross-platform utility for syncing Zoom keyboard screen modules
 
-**Usage**: **`zoom-sync`** \[**`-b`**=_`BOARD`_\] \[_`COMMAND ...`_\]
+**Usage**: **`zoom-sync`** \[**`--auto`** | **`--zoom65v3`** | **`--zoom-tkl-dyna`**\] \[_`COMMAND ...`_\]
+
+
+
+**Board selection:**
+- **`    --auto`** &mdash; 
+  Auto-detect connected board (default)
+- **`    --zoom65v3`** &mdash; 
+  Zoom65 V3
+- **`    --zoom-tkl-dyna`** &mdash; 
+  Zoom TKL Dyna
 
 
 
 **Available options:**
-- **`-b`**, **`--board`**=_`BOARD`_ &mdash; 
-  Board to use (auto, zoom65v3, zoom-tkl-dyna). Defaults to auto-detection.
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 
@@ -58,6 +66,8 @@ Run with a system tray menu for GUI control
 Set specific options on the keyboard
 
 **Usage**: **`zoom-sync`** **`set`** _`COMMAND ...`_
+
+
 
 **Available options:**
 - **`-h`**, **`--help`** &mdash; 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ Set specific options on the keyboard
 - **`screen`** &mdash; 
   Change current screen
 - **`theme`** &mdash; 
-  Set screen theme colors (zoom-tkl-dyna only)
+  Set screen theme colors
 - **`image`** &mdash; 
   Upload static image
 - **`gif`** &mdash; 
@@ -140,7 +140,7 @@ Set weather data
 
 Set system info
 
-**Usage**: **`zoom-sync`** **`set`** **`system`** \[**`-f`**\] (\[**`--cpu`**=_`LABEL`_\] | **`-c`**=_`TEMP`_) (\[**`--gpu`**=_`ID`_\] | **`-g`**=_`TEMP`_) \[**`-d`**=_`ARG`_\]
+**Usage**: **`zoom-sync`** **`set`** **`system`** \[**`-f`**\] (\[**`--cpu`**=_`LABEL`_\] | **`-c`**=_`TEMP`_) (\[**`--gpu`**=_`ID`_\] | **`-g`**=_`TEMP`_) \[**`-d`**=_`SPEED`_\]
 
 **Available options:**
 - **`-f`**, **`--farenheit`** &mdash; 
@@ -157,7 +157,7 @@ Set system info
   [default: 0]
 - **`-g`**, **`--gpu-temp`**=_`TEMP`_ &mdash; 
   Manually set GPU temperature
-- **`-d`**, **`--download`**=_`ARG`_ &mdash; 
+- **`-d`**, **`--download`**=_`SPEED`_ &mdash; 
   Manually set download speed
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
@@ -188,20 +188,20 @@ Change current screen
 
 ## zoom-sync set theme
 
-Set screen theme colors (zoom-tkl-dyna only)
+Set screen theme colors
 
-**Usage**: **`zoom-sync`** **`set`** **`theme`** \[**`-b`**=_`ARG`_\] \[**`-c`**=_`ARG`_\] \[**`-i`**=_`ARG`_\]
+**Usage**: **`zoom-sync`** **`set`** **`theme`** \[**`-b`**=_`COLOR`_\] \[**`-c`**=_`COLOR`_\] \[**`-i`**=_`ID`_\]
 
 **Available options:**
-- **`-b`**, **`--bg`**=_`ARG`_ &mdash; 
+- **`-b`**, **`--bg`**=_`COLOR`_ &mdash; 
   Background color (hex: #RRGGBB or #RGB)
    
   [default: #000000]
-- **`-c`**, **`--color`**=_`ARG`_ &mdash; 
+- **`-c`**, **`--color`**=_`COLOR`_ &mdash; 
   Font/foreground color (hex: #RRGGBB or #RGB)
    
   [default: #ffffff]
-- **`-i`**, **`--id`**=_`ARG`_ &mdash; 
+- **`-i`**, **`--id`**=_`ID`_ &mdash; 
   Theme preset ID
 - **`-h`**, **`--help`** &mdash; 
   Prints help information

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
   * [`zoom-sync set weather`↴](#zoom-sync-set-weather)
   * [`zoom-sync set system`↴](#zoom-sync-set-system)
   * [`zoom-sync set screen`↴](#zoom-sync-set-screen)
+  * [`zoom-sync set theme`↴](#zoom-sync-set-theme)
   * [`zoom-sync set image`↴](#zoom-sync-set-image)
   * [`zoom-sync set image clear`↴](#zoom-sync-set-image-clear)
   * [`zoom-sync set gif`↴](#zoom-sync-set-gif)
@@ -26,7 +27,7 @@ Cross-platform utility for syncing zoom65v3 screen modules
 
 **Available options:**
 - **`-b`**, **`--board`**=_`BOARD`_ &mdash; 
-  Board to use (auto, zoom65v3). Defaults to auto-detection.
+  Board to use (auto, zoom65v3, zoom-tkl-dyna). Defaults to auto-detection.
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 
@@ -73,6 +74,8 @@ Set specific options on the keyboard
   Set system info
 - **`screen`** &mdash; 
   Change current screen
+- **`theme`** &mdash; 
+  Set screen theme colors (zoom-tkl-dyna only)
 - **`image`** &mdash; 
   Upload static image
 - **`gif`** &mdash; 
@@ -179,6 +182,27 @@ Change current screen
 
 
 **Available options:**
+- **`-h`**, **`--help`** &mdash; 
+  Prints help information
+
+
+## zoom-sync set theme
+
+Set screen theme colors (zoom-tkl-dyna only)
+
+**Usage**: **`zoom-sync`** **`set`** **`theme`** \[**`-b`**=_`ARG`_\] \[**`-c`**=_`ARG`_\] \[**`-i`**=_`ARG`_\]
+
+**Available options:**
+- **`-b`**, **`--bg`**=_`ARG`_ &mdash; 
+  Background color (hex: #RRGGBB or #RGB)
+   
+  [default: #000000]
+- **`-c`**, **`--color`**=_`ARG`_ &mdash; 
+  Font/foreground color (hex: #RRGGBB or #RGB)
+   
+  [default: #ffffff]
+- **`-i`**, **`--id`**=_`ARG`_ &mdash; 
+  Theme preset ID
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,19 +20,13 @@
 
 Cross-platform utility for syncing zoom65v3 screen modules
 
-**Usage**: **`zoom-sync`** \[**`--auto`** | **`--zoom65v3`**\] \[_`COMMAND ...`_\]
-
-
-
-**Board selection:**
-- **`    --auto`** &mdash; 
-  Auto-detect connected board (default)
-- **`    --zoom65v3`** &mdash; 
-  Zoom65 V3
+**Usage**: **`zoom-sync`** \[**`-b`**=_`BOARD`_\] \[_`COMMAND ...`_\]
 
 
 
 **Available options:**
+- **`-b`**, **`--board`**=_`BOARD`_ &mdash; 
+  Board to use (auto, zoom65v3). Defaults to auto-detection.
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 

--- a/docs/zoom-sync.1
+++ b/docs/zoom-sync.1
@@ -9,9 +9,9 @@
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fICOMMAND ...\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtime\fP\fR \fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBweather\fP\fR \fP\fR[\fP\fB\-f\fP\fR] (\fP\fB\-\-no\-weather\fP\fR | [\fP\fB\-\-coords\fP\fR \fP\fILAT\fP\fR \fP\fILON\fP\fR] | \fP\fB\-w\fP\fR \fP\fIWMO\fP\fR \fP\fICUR\fP\fR \fP\fIMIN\fP\fR \fP\fIMAX\fP\fR)\fP\fR
-\fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBsystem\fP\fR \fP\fR[\fP\fB\-f\fP\fR] ([\fP\fB\-\-cpu\fP\fR=\fP\fILABEL\fP\fR] | \fP\fB\-c\fP\fR=\fP\fITEMP\fP\fR) ([\fP\fB\-\-gpu\fP\fR=\fP\fIID\fP\fR] | \fP\fB\-g\fP\fR=\fP\fITEMP\fP\fR) [\fP\fB\-d\fP\fR=\fP\fIARG\fP\fR]\fP\fR
+\fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBsystem\fP\fR \fP\fR[\fP\fB\-f\fP\fR] ([\fP\fB\-\-cpu\fP\fR=\fP\fILABEL\fP\fR] | \fP\fB\-c\fP\fR=\fP\fITEMP\fP\fR) ([\fP\fB\-\-gpu\fP\fR=\fP\fIID\fP\fR] | \fP\fB\-g\fP\fR=\fP\fITEMP\fP\fR) [\fP\fB\-d\fP\fR=\fP\fISPEED\fP\fR]\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBscreen\fP\fR \fP\fR(\fP\fB\-s\fP\fR=\fP\fIPOSITION\fP\fR | \fP\fB\-\-up\fP\fR | \fP\fB\-\-down\fP\fR | \fP\fB\-\-switch\fP\fR)\fP\fR
-\fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtheme\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-c\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-i\fP\fR=\fP\fIARG\fP\fR]\fP\fR
+\fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtheme\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fICOLOR\fP\fR] [\fP\fB\-c\fP\fR=\fP\fICOLOR\fP\fR] [\fP\fB\-i\fP\fR=\fP\fIID\fP\fR]\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBimage\fP\fR \fP\fR([\fP\fB\-n\fP\fR] [\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] \fP\fIPATH\fP\fR | \fP\fICOMMAND ...\fP\fR)\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBimage\fP\fR \fP\fBclear\fP\fR \fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBgif\fP\fR \fP\fR([\fP\fB\-n\fP\fR] [\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] \fP\fIPATH\fP\fR | \fP\fICOMMAND ...\fP\fR)\fP\fR
@@ -90,7 +90,7 @@
 .PP
 .TP
 \fBtheme\fP
-\fRSet screen theme colors (zoom\-tkl\-dyna only)\fP
+\fRSet screen theme colors\fP
 .PP
 .TP
 \fBimage\fP
@@ -177,7 +177,7 @@ unitless.\fP
 .SH NAME
 \fRzoom\-sync \- \fP\fRSet system info\fP
 .SH SYNOPSIS
-\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBsystem\fP\fR \fP\fR[\fP\fB\-f\fP\fR] ([\fP\fB\-\-cpu\fP\fR=\fP\fILABEL\fP\fR] | \fP\fB\-c\fP\fR=\fP\fITEMP\fP\fR) ([\fP\fB\-\-gpu\fP\fR=\fP\fIID\fP\fR] | \fP\fB\-g\fP\fR=\fP\fITEMP\fP\fR) [\fP\fB\-d\fP\fR=\fP\fIARG\fP\fR]\fP
+\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBsystem\fP\fR \fP\fR[\fP\fB\-f\fP\fR] ([\fP\fB\-\-cpu\fP\fR=\fP\fILABEL\fP\fR] | \fP\fB\-c\fP\fR=\fP\fITEMP\fP\fR) ([\fP\fB\-\-gpu\fP\fR=\fP\fIID\fP\fR] | \fP\fB\-g\fP\fR=\fP\fITEMP\fP\fR) [\fP\fB\-d\fP\fR=\fP\fISPEED\fP\fR]\fP
 .PP
 .SS AVAILABLE\ OPTIONS:
 .TP
@@ -207,7 +207,7 @@ unitless.\fP
 \fRManually set GPU temperature\fP
 .PP
 .TP
-\fB\-d\fP\fR, \fP\fB\-\-download\fP\fR=\fP\fIARG\fP
+\fB\-d\fP\fR, \fP\fB\-\-download\fP\fR=\fP\fISPEED\fP
 \fRManually set download speed\fP
 .PP
 .TP
@@ -246,27 +246,27 @@ unitless.\fP
 .PP
 .SH ZOOM-SYNC\ SET\ THEME\ 
 .SH NAME
-\fRzoom\-sync \- \fP\fRSet screen theme colors (zoom\-tkl\-dyna only)\fP
+\fRzoom\-sync \- \fP\fRSet screen theme colors\fP
 .SH SYNOPSIS
-\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtheme\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-c\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-i\fP\fR=\fP\fIARG\fP\fR]\fP
+\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtheme\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fICOLOR\fP\fR] [\fP\fB\-c\fP\fR=\fP\fICOLOR\fP\fR] [\fP\fB\-i\fP\fR=\fP\fIID\fP\fR]\fP
 .PP
 .SS AVAILABLE\ OPTIONS:
 .TP
-\fB\-b\fP\fR, \fP\fB\-\-bg\fP\fR=\fP\fIARG\fP
+\fB\-b\fP\fR, \fP\fB\-\-bg\fP\fR=\fP\fICOLOR\fP
 \fRBackground color (hex: #RRGGBB or #RGB)\fP
 .PP
 .TP
 \fR[default: #000000]\fP
 .PP
 .TP
-\fB\-c\fP\fR, \fP\fB\-\-color\fP\fR=\fP\fIARG\fP
+\fB\-c\fP\fR, \fP\fB\-\-color\fP\fR=\fP\fICOLOR\fP
 \fRFont/foreground color (hex: #RRGGBB or #RGB)\fP
 .PP
 .TP
 \fR[default: #ffffff]\fP
 .PP
 .TP
-\fB\-i\fP\fR, \fP\fB\-\-id\fP\fR=\fP\fIARG\fP
+\fB\-i\fP\fR, \fP\fB\-\-id\fP\fR=\fP\fIID\fP
 \fRTheme preset ID\fP
 .PP
 .TP

--- a/docs/zoom-sync.1
+++ b/docs/zoom-sync.1
@@ -4,7 +4,7 @@
 .PP
 .SH SYNOPSIS
 .nf
-\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-\-auto\fP\fR | \fP\fB\-\-zoom65v3\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP\fR
+\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIBOARD\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBtray\fP\fR \fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fICOMMAND ...\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtime\fP\fR \fP\fR
@@ -22,19 +22,13 @@
 .SH NAME
 \fRzoom\-sync \- \fP\fRCross\-platform utility for syncing zoom65v3 screen modules\fP
 .SH SYNOPSIS
-\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-\-auto\fP\fR | \fP\fB\-\-zoom65v3\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP
-.PP
-.SS BOARD\ SELECTION:
-.TP
-\fB    \-\-auto\fP
-\fRAuto\-detect connected board (default)\fP
-.PP
-.TP
-\fB    \-\-zoom65v3\fP
-\fRZoom65 V3\fP
-.PP
+\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIBOARD\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP
 .PP
 .SS AVAILABLE\ OPTIONS:
+.TP
+\fB\-b\fP\fR, \fP\fB\-\-board\fP\fR=\fP\fIBOARD\fP
+\fRBoard to use (auto, zoom65v3). Defaults to auto\-detection.\fP
+.PP
 .TP
 \fB\-h\fP\fR, \fP\fB\-\-help\fP
 \fRPrints help information\fP

--- a/docs/zoom-sync.1
+++ b/docs/zoom-sync.1
@@ -4,7 +4,7 @@
 .PP
 .SH SYNOPSIS
 .nf
-\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIBOARD\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP\fR
+\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-\-auto\fP\fR | \fP\fB\-\-zoom65v3\fP\fR | \fP\fB\-\-zoom\-tkl\-dyna\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBtray\fP\fR \fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fICOMMAND ...\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtime\fP\fR \fP\fR
@@ -21,15 +21,25 @@
 .fi
 .SH ZOOM-SYNC\ 
 .SH NAME
-\fRzoom\-sync \- \fP\fRCross\-platform utility for syncing zoom65v3 screen modules\fP
+\fRzoom\-sync \- \fP\fRCross\-platform utility for syncing Zoom keyboard screen modules\fP
 .SH SYNOPSIS
-\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIBOARD\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP
+\fBzoom\-sync\fP\fR \fP\fR[\fP\fB\-\-auto\fP\fR | \fP\fB\-\-zoom65v3\fP\fR | \fP\fB\-\-zoom\-tkl\-dyna\fP\fR] [\fP\fICOMMAND ...\fP\fR]\fP
+.PP
+.SS BOARD\ SELECTION:
+.TP
+\fB    \-\-auto\fP
+\fRAuto\-detect connected board (default)\fP
+.PP
+.TP
+\fB    \-\-zoom65v3\fP
+\fRZoom65 V3\fP
+.PP
+.TP
+\fB    \-\-zoom\-tkl\-dyna\fP
+\fRZoom TKL Dyna\fP
+.PP
 .PP
 .SS AVAILABLE\ OPTIONS:
-.TP
-\fB\-b\fP\fR, \fP\fB\-\-board\fP\fR=\fP\fIBOARD\fP
-\fRBoard to use (auto, zoom65v3, zoom\-tkl\-dyna). Defaults to auto\-detection.\fP
-.PP
 .TP
 \fB\-h\fP\fR, \fP\fB\-\-help\fP
 \fRPrints help information\fP
@@ -64,6 +74,8 @@
 \fRzoom\-sync \- \fP\fRSet specific options on the keyboard\fP
 .SH SYNOPSIS
 \fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fICOMMAND ...\fP
+.PP
+\fR\fP
 .PP
 .SS AVAILABLE\ OPTIONS:
 .TP

--- a/docs/zoom-sync.1
+++ b/docs/zoom-sync.1
@@ -11,6 +11,7 @@
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBweather\fP\fR \fP\fR[\fP\fB\-f\fP\fR] (\fP\fB\-\-no\-weather\fP\fR | [\fP\fB\-\-coords\fP\fR \fP\fILAT\fP\fR \fP\fILON\fP\fR] | \fP\fB\-w\fP\fR \fP\fIWMO\fP\fR \fP\fICUR\fP\fR \fP\fIMIN\fP\fR \fP\fIMAX\fP\fR)\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBsystem\fP\fR \fP\fR[\fP\fB\-f\fP\fR] ([\fP\fB\-\-cpu\fP\fR=\fP\fILABEL\fP\fR] | \fP\fB\-c\fP\fR=\fP\fITEMP\fP\fR) ([\fP\fB\-\-gpu\fP\fR=\fP\fIID\fP\fR] | \fP\fB\-g\fP\fR=\fP\fITEMP\fP\fR) [\fP\fB\-d\fP\fR=\fP\fIARG\fP\fR]\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBscreen\fP\fR \fP\fR(\fP\fB\-s\fP\fR=\fP\fIPOSITION\fP\fR | \fP\fB\-\-up\fP\fR | \fP\fB\-\-down\fP\fR | \fP\fB\-\-switch\fP\fR)\fP\fR
+\fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtheme\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-c\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-i\fP\fR=\fP\fIARG\fP\fR]\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBimage\fP\fR \fP\fR([\fP\fB\-n\fP\fR] [\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] \fP\fIPATH\fP\fR | \fP\fICOMMAND ...\fP\fR)\fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBimage\fP\fR \fP\fBclear\fP\fR \fP\fR
 \fP\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBgif\fP\fR \fP\fR([\fP\fB\-n\fP\fR] [\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] \fP\fIPATH\fP\fR | \fP\fICOMMAND ...\fP\fR)\fP\fR
@@ -27,7 +28,7 @@
 .SS AVAILABLE\ OPTIONS:
 .TP
 \fB\-b\fP\fR, \fP\fB\-\-board\fP\fR=\fP\fIBOARD\fP
-\fRBoard to use (auto, zoom65v3). Defaults to auto\-detection.\fP
+\fRBoard to use (auto, zoom65v3, zoom\-tkl\-dyna). Defaults to auto\-detection.\fP
 .PP
 .TP
 \fB\-h\fP\fR, \fP\fB\-\-help\fP
@@ -86,6 +87,10 @@
 .TP
 \fBscreen\fP
 \fRChange current screen\fP
+.PP
+.TP
+\fBtheme\fP
+\fRSet screen theme colors (zoom\-tkl\-dyna only)\fP
 .PP
 .TP
 \fBimage\fP
@@ -235,6 +240,35 @@ unitless.\fP
 .PP
 .PP
 .SS AVAILABLE\ OPTIONS:
+.TP
+\fB\-h\fP\fR, \fP\fB\-\-help\fP
+\fRPrints help information\fP
+.PP
+.SH ZOOM-SYNC\ SET\ THEME\ 
+.SH NAME
+\fRzoom\-sync \- \fP\fRSet screen theme colors (zoom\-tkl\-dyna only)\fP
+.SH SYNOPSIS
+\fBzoom\-sync\fP\fR \fP\fBset\fP\fR \fP\fBtheme\fP\fR \fP\fR[\fP\fB\-b\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-c\fP\fR=\fP\fIARG\fP\fR] [\fP\fB\-i\fP\fR=\fP\fIARG\fP\fR]\fP
+.PP
+.SS AVAILABLE\ OPTIONS:
+.TP
+\fB\-b\fP\fR, \fP\fB\-\-bg\fP\fR=\fP\fIARG\fP
+\fRBackground color (hex: #RRGGBB or #RGB)\fP
+.PP
+.TP
+\fR[default: #000000]\fP
+.PP
+.TP
+\fB\-c\fP\fR, \fP\fB\-\-color\fP\fR=\fP\fIARG\fP
+\fRFont/foreground color (hex: #RRGGBB or #RGB)\fP
+.PP
+.TP
+\fR[default: #ffffff]\fP
+.PP
+.TP
+\fB\-i\fP\fR, \fP\fB\-\-id\fP\fR=\fP\fIARG\fP
+\fRTheme preset ID\fP
+.PP
 .TP
 \fB\-h\fP\fR, \fP\fB\-\-help\fP
 \fRPrints help information\fP

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -35,14 +35,15 @@ impl std::fmt::Display for BoardKind {
         match self {
             Self::Auto => write!(f, "auto"),
             Self::Zoom65v3 => write!(f, "zoom65v3"),
+            Self::ZoomTklDyna => write!(f, "zoom-tkl-dyna"),
         }
     }
 }
 
 /// Check if a HID device matches the board info
 fn matches(device: &hidapi::DeviceInfo, info: &BoardInfo) -> bool {
-    device.vendor_id() == info.vendor_id
-        && device.product_id() == info.product_id
+    info.vendor_id.is_none_or(|vid| device.vendor_id() == vid)
+        && info.product_id.is_none_or(|pid| device.product_id() == pid)
         && info.usage_page.is_none_or(|up| device.usage_page() == up)
         && info.usage.is_none_or(|u| device.usage() == u)
 }

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 use bpaf::Bpaf;
 use hidapi::HidApi;
 use zoom65v3::{Zoom65v3, INFO as ZOOM65V3_INFO};
-use zoom_tkl_dyna::{ZoomTklDyna, INFO as ZOOM_TKL_DYNA_INFO};
 use zoom_sync_core::{Board, BoardError, BoardInfo, Capabilities};
+use zoom_tkl_dyna::{ZoomTklDyna, INFO as ZOOM_TKL_DYNA_INFO};
 
 /// Supported board types
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Bpaf)]
@@ -27,7 +27,7 @@ impl FromStr for BoardKind {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "auto" => Ok(Self::Auto),
-            "zoom65v3" => Ok(Self::Zoom65v3),
+            "zoom65v3" | "65v3" => Ok(Self::Zoom65v3),
             "zoom-tkl-dyna" | "zoomtkldyna" => Ok(Self::ZoomTklDyna),
             _ => Err(format!(
                 "unknown board: {s}. Available: auto, zoom65v3, zoom-tkl-dyna"
@@ -53,10 +53,6 @@ fn matches(device: &hidapi::DeviceInfo, info: &BoardInfo) -> bool {
         && info.usage_page.is_none_or(|up| device.usage_page() == up)
         && info.usage.is_none_or(|u| device.usage() == u)
 }
-
-/// All known board infos for iteration
-#[allow(dead_code)]
-pub const ALL_BOARDS: &[&BoardInfo] = &[&ZOOM65V3_INFO, &ZOOM_TKL_DYNA_INFO];
 
 impl BoardKind {
     /// Get the static board info without connecting
@@ -97,7 +93,8 @@ impl BoardKind {
                             time: true,
                             weather: true,
                             system_info: true,
-                            screen: true,
+                            screen_pos: true,
+                            screen_nav: true,
                             image: true,
                             gif: true,
                             theme: true,
@@ -129,11 +126,5 @@ impl BoardKind {
             BoardKind::Zoom65v3 => Ok(Box::new(Zoom65v3::open()?)),
             BoardKind::ZoomTklDyna => Ok(Box::new(ZoomTklDyna::open()?)),
         }
-    }
-
-    /// List all supported board CLI names
-    #[allow(dead_code)]
-    pub fn supported_boards() -> &'static [&'static str] {
-        &["auto", "zoom65v3", "zoom-tkl-dyna"]
     }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use std::sync::LazyLock;
 
-use either::Either;
+use either::Either::{self, Left, Right};
 use nvml_wrapper::enum_wrappers::device::TemperatureSensor;
 use nvml_wrapper::{Device, Nvml};
 use sysinfo::{Component, Components};
@@ -40,28 +40,32 @@ pub enum GpuMode {
         u32,
     ),
     Manual(
-        /// Manually set GPU temperature
-        #[bpaf(short('g'), long("gpu-temp"), argument("TEMP"))]
-        u8,
+        /// Manually set GPU stats, temperature. Disables automatic fetching.
+        #[bpaf(long("gpu-temp"), argument("TEMP"), fallback(0))]
+        u32,
+        /// Manually set GPU stats, fanspeed. Disables automatic fetching.
+        #[bpaf(long("gpu-fanspeed"), argument("FAN-SPEED"), fallback(0))]
+        u32
     ),
 }
 
 impl GpuMode {
-    pub fn either(&self) -> Either<GpuTemp, u8> {
+    pub fn either(&self) -> Either<GpuStats, (u32, u32)> {
         match self {
-            GpuMode::Id(i) => Either::Left(GpuTemp::new(*i)),
-            GpuMode::Manual(v) => Either::Right(*v),
+            GpuMode::Id(i) => Either::Left(GpuStats::new(*i)),
+            GpuMode::Manual(temp, fanspeed) => Either::Right((*temp, *fanspeed)),
         }
     }
 }
 
 /// Helper struct to track gpu temperature
-pub struct GpuTemp {
+pub struct GpuStats {
     maybe_device: Option<Device<'static>>,
 }
 
-impl GpuTemp {
-    /// Construct a new gpu temperature monitor, optionally selecting by device index
+impl GpuStats {
+    /// Construct a new gpu monitor, optionally selecting by device index.
+    /// Handles both gpu temp and gpu fan speeds.
     pub fn new(index: u32) -> Self {
         static NVML: LazyLock<Option<Nvml>> = LazyLock::new(|| {
             let nvml = Nvml::init().ok();
@@ -83,17 +87,24 @@ impl GpuTemp {
     }
 
     // Refresh and poll the current temperature
-    pub fn get_temp(&self, farenheit: bool) -> Option<u8> {
+    pub fn get_temp(&self, farenheit: bool) -> Option<u32> {
         self.maybe_device
             .as_ref()
             .and_then(|d| d.temperature(TemperatureSensor::Gpu).ok())
             .map(|v| {
                 if farenheit {
-                    (v as f64 * 9. / 5. + 32.) as u8
+                    (v as f64 * 9. / 5. + 32.) as u32
                 } else {
-                    v as u8
+                    v as u32
                 }
             })
+    }
+
+    // Refresh and poll the current GPU fanspeed
+    pub fn get_fanspeed(&self) -> Option<u32> {
+        self.maybe_device
+            .as_ref()
+            .and_then(|d| d.fan_speed_rpm(0).ok())
     }
 }
 
@@ -171,7 +182,7 @@ pub fn apply_system(
     board: &mut dyn Board,
     farenheit: bool,
     cpu: &mut Either<CpuTemp, u8>,
-    gpu: &Either<GpuTemp, u8>,
+    gpu: &Either<GpuStats, (u32, u32)>,
     download: Option<f32>,
 ) -> Result<(), Box<dyn Error>> {
     let system_info = board
@@ -188,23 +199,52 @@ pub fn apply_system(
         cpu_temp = 99;
     }
 
-    let mut gpu_temp = gpu
+    let gpu_temp_pull = gpu
         .as_ref()
         .map_left(|g| g.get_temp(farenheit).unwrap_or_default())
-        .map_right(|v| *v)
-        .into_inner();
+        .map_right(|v| *v);
+
+    let gpu_fan_speed_pull = gpu
+        .as_ref()
+        .map_left(|g| g.get_fanspeed().unwrap_or_default())
+        .map_right(|v| *v);
+
+    let mut gpu_temp: u32;
+
+    match gpu_temp_pull {
+        Left(temp) => {
+            gpu_temp = temp;
+
+        }
+        Right((temp, _)) => {
+            gpu_temp = temp;
+        }
+    }
+
     if gpu_temp >= 100 {
-        eprintln!("warning: actual gpu temerature at {gpu_temp}. clamping to 99");
+        eprintln!("warning: actual gpu temperature at {gpu_temp}. clamping to 99");
         gpu_temp = 99;
+    }
+
+    let mut gpu_fan_speed: u32;
+
+    match gpu_fan_speed_pull {
+        Left(fanspeed) => {
+            gpu_fan_speed = fanspeed;
+
+        }
+        Right((_, fanspeed)) => {
+            gpu_fan_speed = fanspeed;
+        }
     }
 
     let download = download.unwrap_or_default();
 
     system_info
-        .set_system_info(cpu_temp, gpu_temp, download)
+        .set_system_info(cpu_temp, gpu_temp, download, gpu_fan_speed)
         .map_err(|e| format!("failed to set system info: {e}"))?;
     println!(
-        "updated system info {{ cpu_temp: {cpu_temp}, gpu_temp: {gpu_temp}, download: {download} }}"
+        "updated system info {{ cpu_temp: {cpu_temp}, gpu_temp: {gpu_temp}, download: {download}, gpu_fan_speed: {gpu_fan_speed} }}"
     );
 
     Ok(())

--- a/src/info.rs
+++ b/src/info.rs
@@ -45,7 +45,7 @@ pub enum GpuMode {
         u32,
         /// Manually set GPU stats, fanspeed. Disables automatic fetching.
         #[bpaf(long("gpu-fanspeed"), argument("FAN-SPEED"), fallback(0))]
-        u32
+        u32,
     ),
 }
 
@@ -95,7 +95,7 @@ impl GpuStats {
                 if farenheit {
                     (v as f64 * 9. / 5. + 32.) as u32
                 } else {
-                    v as u32
+                    v
                 }
             })
     }
@@ -214,11 +214,10 @@ pub fn apply_system(
     match gpu_temp_pull {
         Left(temp) => {
             gpu_temp = temp;
-
-        }
+        },
         Right((temp, _)) => {
             gpu_temp = temp;
-        }
+        },
     }
 
     if gpu_temp >= 100 {
@@ -226,17 +225,10 @@ pub fn apply_system(
         gpu_temp = 99;
     }
 
-    let mut gpu_fan_speed: u32;
-
-    match gpu_fan_speed_pull {
-        Left(fanspeed) => {
-            gpu_fan_speed = fanspeed;
-
-        }
-        Right((_, fanspeed)) => {
-            gpu_fan_speed = fanspeed;
-        }
-    }
+    let gpu_fan_speed: u32 = match gpu_fan_speed_pull {
+        Left(fanspeed) => fanspeed,
+        Right((_, fanspeed)) => fanspeed,
+    };
 
     let download = download.unwrap_or_default();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,7 +447,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             .ok_or("failed to decode animation")?;
                             println!("done");
 
-                            // re-encode and upload to keyboard
+                            // re-encode to resized standard gif and upload
                             let encoded = encode_gif(frames, bg.0, nearest, width, height)
                                 .ok_or("failed to encode gif image")?;
                             let len = encoded.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn set_command_for(caps: &Capabilities) -> impl Parser<SetCommand> {
         commands.push(Box::new(system));
     }
 
-    if caps.screen {
+    if caps.screen_pos || caps.screen_nav {
         let screen = screen_args()
             .map(SetCommand::Screen)
             .to_options()
@@ -496,7 +496,8 @@ fn generate_docs() {
         time: true,
         weather: true,
         system_info: true,
-        screen: true,
+        screen_pos: true,
+        screen_nav: true,
         image: true,
         gif: true,
         theme: true,

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -29,29 +29,54 @@ pub enum ScreenArgs {
     Down,
     /// Switch the screen offset
     Switch,
+    /// Reset the screen to default position
+    Reset,
 }
 
 pub fn apply_screen(args: &ScreenArgs, board: &mut dyn Board) -> Result<(), Box<dyn Error>> {
-    let screen = board
-        .as_screen()
-        .ok_or("board does not support screen control")?;
-
     match args {
         ScreenArgs::Screen(pos_id) => {
+            let screen = board
+                .as_screen_pos()
+                .ok_or("board does not support setting screen position")?;
             let positions = screen.screen_positions();
-            let pos = positions.iter().find(|p| p.id == pos_id.0).ok_or_else(|| {
-                let valid: Vec<_> = positions.iter().map(|p| p.id).collect();
-                format!(
-                    "invalid screen position '{}'. Valid: {}",
-                    pos_id.0,
-                    valid.join(", ")
-                )
-            })?;
-            screen.set_screen(pos.id)?;
-        },
-        ScreenArgs::Up => screen.screen_up()?,
-        ScreenArgs::Down => screen.screen_down()?,
-        ScreenArgs::Switch => screen.screen_switch()?,
+            let pos = positions
+                .iter()
+                .find(|p| p.as_id() == pos_id.0)
+                .ok_or_else(|| {
+                    let valid: Vec<_> = positions.iter().map(|p| p.as_id()).collect();
+                    format!(
+                        "invalid screen position '{}'. Valid: {}",
+                        pos_id.0,
+                        valid.join(", ")
+                    )
+                })?;
+            screen.set_screen(pos.as_id())?;
+        }
+        ScreenArgs::Up => {
+            board
+                .as_screen_nav()
+                .ok_or("board does not support screen navigation")?
+                .screen_up()?;
+        }
+        ScreenArgs::Down => {
+            board
+                .as_screen_nav()
+                .ok_or("board does not support screen navigation")?
+                .screen_down()?;
+        }
+        ScreenArgs::Switch => {
+            board
+                .as_screen_nav()
+                .ok_or("board does not support screen navigation")?
+                .screen_switch()?;
+        }
+        ScreenArgs::Reset => {
+            board
+                .as_screen_nav()
+                .ok_or("board does not support screen navigation")?
+                .screen_reset()?;
+        }
     };
     Ok(())
 }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -52,31 +52,31 @@ pub fn apply_screen(args: &ScreenArgs, board: &mut dyn Board) -> Result<(), Box<
                     )
                 })?;
             screen.set_screen(pos.as_id())?;
-        }
+        },
         ScreenArgs::Up => {
             board
                 .as_screen_nav()
                 .ok_or("board does not support screen navigation")?
                 .screen_up()?;
-        }
+        },
         ScreenArgs::Down => {
             board
                 .as_screen_nav()
                 .ok_or("board does not support screen navigation")?
                 .screen_down()?;
-        }
+        },
         ScreenArgs::Switch => {
             board
                 .as_screen_nav()
                 .ok_or("board does not support screen navigation")?
                 .screen_switch()?;
-        }
+        },
         ScreenArgs::Reset => {
             board
                 .as_screen_nav()
                 .ok_or("board does not support screen navigation")?
                 .screen_reset()?;
-        }
+        },
     };
     Ok(())
 }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -19,7 +19,10 @@ impl std::str::FromStr for ScreenPositionId {
 pub enum ScreenArgs {
     Screen(
         /// Reset and move the screen to a specific position.
+        /// Zoom65v3:
         /// [cpu|gpu|download|time|weather|meletrix|zoom65|image|gif|battery]
+        /// Zoom TKL DYNA:
+        /// [up|down|enter|return]
         #[bpaf(short('s'), long("screen"), argument("POSITION"))]
         ScreenPositionId,
     ),

--- a/src/tray/menu.rs
+++ b/src/tray/menu.rs
@@ -83,7 +83,7 @@ impl MenuItems {
         // Update connection status and check features
         let (status_text, has_screen, has_media) = match board.as_mut() {
             Some(b) => {
-                let has_screen = b.as_screen().is_some();
+                let has_screen = b.as_screen_pos().is_some();
                 let has_media = b.as_image().is_some() || b.as_gif().is_some();
                 (
                     format!("{} Connected", b.info().name),

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -441,8 +441,10 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
             }
 
             // Reactive mode keypress handling (Linux only)
+
             Some(Some(res)) = OptionFuture::from(reactive_stream.as_mut().map(|s| s.next())), if board.is_some() => {
                 match res {
+                    #[cfg(target_os = "linux")]
                     Ok(Err(e)) => {
                         eprintln!("reactive stream error: {e}");
                         handle_disconnect(&mut board, &mut state, &menu_items);
@@ -458,6 +460,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                             }
                         }
                     }
+                    #[cfg(target_os = "linux")]
                     Err(_) if is_reactive_running => {
                         is_reactive_running = false;
                         if let Some(ref mut b) = board {

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -279,7 +279,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                             println!("reactive mode disabled");
                         } else if let Some(ref mut b) = board {
                             // Enable reactive mode
-                            if let Some(screen) = b.as_screen() {
+                            if let Some(screen) = b.as_screen_pos() {
                                 let _ = screen.set_screen("image");
                             }
                             let board_name = b.info().name.to_lowercase();
@@ -328,7 +328,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                         #[cfg(target_os = "linux")]
                         if state.config.general.initial_screen == "reactive" {
                             println!("initializing reactive mode");
-                            if let Some(screen) = b.as_screen() {
+                            if let Some(screen) = b.as_screen_pos() {
                                 let _ = screen.set_screen("image");
                             }
                             let board_name = b.info().name.to_lowercase();
@@ -360,7 +360,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                         let skip_initial = false;
 
                         if !skip_initial {
-                            if let Some(screen) = b.as_screen() {
+                            if let Some(screen) = b.as_screen_pos() {
                                 let initial = &state.config.general.initial_screen;
                                 if screen.set_screen(initial).is_ok() {
                                     state.current_screen = Some(initial.clone());
@@ -452,7 +452,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                         if matches!(ev.destructure(), evdev::EventSummary::Key(_, _, _)) {
                             is_reactive_running = true;
                             if let Some(ref mut b) = board {
-                                if let Some(screen) = b.as_screen() {
+                                if let Some(screen) = b.as_screen_nav() {
                                     let _ = screen.screen_switch();
                                 }
                             }
@@ -461,8 +461,8 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                     Err(_) if is_reactive_running => {
                         is_reactive_running = false;
                         if let Some(ref mut b) = board {
-                            if let Some(screen) = b.as_screen() {
-                                let _ = screen.reset_screen();
+                            if let Some(screen) = b.as_screen_nav() {
+                                let _ = screen.screen_reset();
                                 let _ = screen.screen_switch();
                                 let _ = screen.screen_switch();
                             }
@@ -503,7 +503,7 @@ async fn handle_command(
             }
 
             if let Some(ref mut b) = board {
-                if let Some(screen) = b.as_screen() {
+                if let Some(screen) = b.as_screen_pos() {
                     match screen.set_screen(id) {
                         Ok(()) => {
                             state.current_screen = Some(id.to_string());

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -24,7 +24,7 @@ use zoom_sync_core::Board;
 
 use crate::config::Config;
 use crate::detection::BoardKind;
-use crate::info::{apply_system, CpuTemp, GpuTemp};
+use crate::info::{apply_system, CpuTemp, GpuStats};
 use crate::media::{encode_gif, encode_image};
 use crate::weather::apply_weather;
 
@@ -122,7 +122,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
 
     // Temperature monitors (initialized when board connects)
     let mut cpu: Option<Either<CpuTemp, u8>> = None;
-    let mut gpu: Option<Either<GpuTemp, u8>> = None;
+    let mut gpu: Option<Either<GpuStats, (u32, u32)>> = None;
 
     // Weather args
     let mut weather_args = build_weather_args(&state.config);
@@ -321,7 +321,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                         // Initialize temperature monitors
                         if state.config.system_info.enabled {
                             cpu = Some(Either::Left(CpuTemp::new(&state.config.system_info.cpu_source)));
-                            gpu = Some(Either::Left(GpuTemp::new(state.config.system_info.gpu_device)));
+                            gpu = Some(Either::Left(GpuStats::new(state.config.system_info.gpu_device)));
                         }
 
                         // Initialize reactive mode if configured (Linux only)
@@ -492,7 +492,7 @@ async fn handle_command(
     state: &mut TrayState,
     menu_items: &menu::MenuItems,
     cpu: &mut Option<Either<CpuTemp, u8>>,
-    gpu: &mut Option<Either<GpuTemp, u8>>,
+    gpu: &mut Option<Either<GpuStats, (u32, u32)>>,
     weather_args: &mut crate::weather::WeatherArgs,
 ) -> CommandResult {
     match cmd {
@@ -535,7 +535,7 @@ async fn handle_command(
                 *cpu = Some(Either::Left(CpuTemp::new(
                     &state.config.system_info.cpu_source,
                 )));
-                *gpu = Some(Either::Left(GpuTemp::new(
+                *gpu = Some(Either::Left(GpuStats::new(
                     state.config.system_info.gpu_device,
                 )));
             }

--- a/src/weather.rs
+++ b/src/weather.rs
@@ -46,13 +46,13 @@ pub enum WeatherArgs {
         wmo: u8,
         /// Current temperature
         #[bpaf(positional("CUR"))]
-        current: u8,
+        current: i16,
         /// Minumum temperature
         #[bpaf(positional("MIN"))]
-        min: u8,
+        min: i16,
         /// Maximum temperature
         #[bpaf(positional("MAX"))]
-        max: u8,
+        max: i16,
     },
 }
 
@@ -147,9 +147,9 @@ pub async fn apply_weather(
                             .set_weather(
                                 data.wmo,
                                 data.is_day,
-                                data.current as u8,
-                                data.min as u8,
-                                data.max as u8,
+                                data.current.round() as i16,
+                                data.min.round() as i16,
+                                data.max.round() as i16,
                             )
                             .map_err(|e| format!("failed to set weather: {e}"))?;
                         println!(


### PR DESCRIPTION
Adds experimental support for the Zoom TKL Dyna (untested!)

Primarily based off of reverse engineering the web driver: https://zoomtkldyna.meletrix.com/

Certain functions were confirmed against @Phan-2k2's fork of zoom sync with basic support for the tkl: https://github.com/Phan-2k2/zoom-sync-tkl-dyna/tree/1440426e74affd2f2dffbe4a852b9184543712bf 
Notably, the screen position commands were verified and the vendor/product ids are used.

## Changes

- Tweaked weather feature trait to be more generic
- Added theme board feature trait
- Added zoom-tkl-dyna hid driver
- Dynamically assemble the cli parser and helptexts depending on board selection (or auto-detection)
- Makes tray respect the board flags
- `-b/--board <kind>` -> `--auto|--zoom65v3|--zoom-tkl-dyna`

## Notes

I do not have this hardware, so I can only re-implement what I find in the web drivers (which should be working). Needs testing!!