### PR TITLE
Zoom TKL Dyna Sysinfo Feature Update

### DIFF
--- a/boards/core/src/features.rs
+++ b/boards/core/src/features.rs
@@ -60,9 +60,9 @@ pub trait HasWeather {
     ) -> Result<()>;
 }
 
-/// System info display capability (CPU temp, GPU temp, download speed)
+/// System info display capability (CPU temp, GPU temp, download speed, fan speed (currently set to GPU fans w/gpu driver))
 pub trait HasSystemInfo {
-    fn set_system_info(&mut self, cpu: u8, gpu: u8, download: f32) -> Result<()>;
+    fn set_system_info(&mut self, cpu: u8, gpu: u32, download: f32, fan_rpm: u32) -> Result<()>;
 }
 
 /// Screen position control capability

--- a/boards/zoom-tkl-dyna/src/lib.rs
+++ b/boards/zoom-tkl-dyna/src/lib.rs
@@ -222,7 +222,14 @@ impl ZoomTklDyna {
         download_rate: f32,
         gpu_fan_speed: u32,
     ) -> Result<()> {
-        let packet = abi::set_system_info(cpu_temp, gpu_temp, download_rate, gpu_fan_speed);
+
+        let mut gpu_fan_speed_adjusted = gpu_fan_speed;
+        if gpu_fan_speed >= 10000 {
+            eprintln!("warning: actual fan speed at {gpu_fan_speed}. clamping to 9999");
+            gpu_fan_speed_adjusted = 9999;
+        }
+
+        let packet = abi::set_system_info(cpu_temp, gpu_temp, download_rate, gpu_fan_speed_adjusted);
         self.execute(packet)
     }
 

--- a/boards/zoom65v3/src/lib.rs
+++ b/boards/zoom65v3/src/lib.rs
@@ -194,11 +194,12 @@ impl Zoom65v3 {
     pub fn set_system_info(
         &mut self,
         cpu_temp: u8,
-        gpu_temp: u8,
+        gpu_temp: u32,
         download_rate: f32,
     ) -> Result<()> {
         let download = DumbFloat16::new(download_rate);
-        let res = self.execute(abi::set_system_info(cpu_temp, gpu_temp, download))?;
+        let gpu_temp_cast: [u8; 4] = gpu_temp.to_be_bytes();
+        let res = self.execute(abi::set_system_info(cpu_temp, gpu_temp_cast[3], download))?;
         (res[1] == 1 && res[2] == 1)
             .then_some(())
             .ok_or(BoardError::CommandFailed("device rejected command"))
@@ -379,8 +380,9 @@ impl HasWeather for Zoom65v3 {
     }
 }
 
+// fan speed (the 4th arg for sysinfo) not supported on zoom65v3, thus not included.
 impl HasSystemInfo for Zoom65v3 {
-    fn set_system_info(&mut self, cpu: u8, gpu: u8, download: f32) -> Result<()> {
+    fn set_system_info(&mut self, cpu: u8, gpu: u32, download: f32, _: u32) -> Result<()> {
         Zoom65v3::set_system_info(self, cpu, gpu, download)
     }
 }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -122,7 +122,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
 
     // Temperature monitors (initialized when board connects)
     let mut cpu: Option<Either<CpuTemp, u8>> = None;
-    let mut gpu: Option<Either<GpuStats, u32>> = None;
+    let mut gpu: Option<Either<GpuStats, (u32, u32)>> = None;
 
     // Weather args
     let mut weather_args = build_weather_args(&state.config);
@@ -492,7 +492,7 @@ async fn handle_command(
     state: &mut TrayState,
     menu_items: &menu::MenuItems,
     cpu: &mut Option<Either<CpuTemp, u8>>,
-    gpu: &mut Option<Either<GpuStats, u32>>,
+    gpu: &mut Option<Either<GpuStats, (u32, u32)>>,
     weather_args: &mut crate::weather::WeatherArgs,
 ) -> CommandResult {
     match cmd {

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -24,7 +24,7 @@ use zoom_sync_core::Board;
 
 use crate::config::Config;
 use crate::detection::BoardKind;
-use crate::info::{apply_system, CpuTemp, GpuTemp};
+use crate::info::{apply_system, CpuTemp, GpuStats};
 use crate::media::{encode_gif, encode_image};
 use crate::weather::apply_weather;
 
@@ -122,7 +122,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
 
     // Temperature monitors (initialized when board connects)
     let mut cpu: Option<Either<CpuTemp, u8>> = None;
-    let mut gpu: Option<Either<GpuTemp, u8>> = None;
+    let mut gpu: Option<Either<GpuStats, u32>> = None;
 
     // Weather args
     let mut weather_args = build_weather_args(&state.config);
@@ -321,7 +321,7 @@ async fn async_tray_app(board_kind: BoardKind) -> Result<(), Box<dyn Error>> {
                         // Initialize temperature monitors
                         if state.config.system_info.enabled {
                             cpu = Some(Either::Left(CpuTemp::new(&state.config.system_info.cpu_source)));
-                            gpu = Some(Either::Left(GpuTemp::new(state.config.system_info.gpu_device)));
+                            gpu = Some(Either::Left(GpuStats::new(state.config.system_info.gpu_device)));
                         }
 
                         // Initialize reactive mode if configured (Linux only)
@@ -492,7 +492,7 @@ async fn handle_command(
     state: &mut TrayState,
     menu_items: &menu::MenuItems,
     cpu: &mut Option<Either<CpuTemp, u8>>,
-    gpu: &mut Option<Either<GpuTemp, u8>>,
+    gpu: &mut Option<Either<GpuStats, u32>>,
     weather_args: &mut crate::weather::WeatherArgs,
 ) -> CommandResult {
     match cmd {
@@ -535,7 +535,7 @@ async fn handle_command(
                 *cpu = Some(Either::Left(CpuTemp::new(
                     &state.config.system_info.cpu_source,
                 )));
-                *gpu = Some(Either::Left(GpuTemp::new(
+                *gpu = Some(Either::Left(GpuStats::new(
                     state.config.system_info.gpu_device,
                 )));
             }


### PR DESCRIPTION
TL;DR: Adds support for GPU Temp, CPU Temp, GPU Fan Speed, and Download speed for Zoom TKL DYNA

Tested on my personal TKL Dyna, though this affects 65v3 as well, so please check functionality before merging.

Few changes here: 

Updated the GPUTemp Struct to a GPUStats Struct, so that I could add gpu fan speed to the data that we collect.
Since the TKL DYNA has the ability to display fan RPMs, I figured that I could link it to something we already have access to, gpu fan speed seemed reasonable. Didn't want to hunt down CPU fan speed (that's motherboard dependent anyways and can totally be a pain in the butt to find).

I did update the struct and apply it to the Zoom65v3 as well, though it ignores the temp value, which I presume isn't something that can be displayed on that board.
